### PR TITLE
feat: add opencode and reasonix integration

### DIFF
--- a/scripts/opencode-plugin.js
+++ b/scripts/opencode-plugin.js
@@ -1,0 +1,80 @@
+/**
+ * AI Light OpenCode Plugin
+ *
+ * Sends OpenCode session events to AI Light's local HTTP server.
+ *
+ * ## Installation
+ *
+ * Add to ~/.config/opencode/opencode.json:
+ * {
+ *   "plugins": {
+ *     "https://raw.githubusercontent.com/lcy05/ai-light/main/scripts/opencode-plugin.js": {}
+ *   }
+ * }
+ *
+ * Or copy this file to ~/.config/opencode/plugins/ai-light.js
+ */
+
+/// <reference types="@opencode-ai/plugin" />
+
+/**
+ * @type {import("@opencode-ai/plugin").Plugin}
+ */
+export default async function aiLightPlugin(ctx) {
+  const AI_LIGHT_URL =
+    process.env.AI_LIGHT_URL ||
+    "http://127.0.0.1:17321";
+
+  function baseUrl() {
+    return AI_LIGHT_URL.replace(/\/+$/, "");
+  }
+
+  async function sendEvent(eventType, payload) {
+    try {
+      const url = `${baseUrl()}/events`;
+      const body = JSON.stringify({
+        event_type: eventType,
+        session_id: payload.session?.id || "unknown",
+        sessionId: payload.session?.id || "unknown",
+        cwd: payload.session?.cwd || payload.cwd || process.cwd(),
+        tool_call: payload.tool?.name || payload.toolName || null,
+        toolName: payload.tool?.name || payload.toolName || null,
+        tool_source: "opencode",
+        source: "opencode",
+      });
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      if (!response.ok) {
+        console.error(`AI Light: event ${eventType} failed (${response.status})`);
+      }
+    } catch (error) {
+      // AI Light not running — silently ignore
+    }
+  }
+
+  return {
+    "session.created": async (input) => {
+      await sendEvent("session-start", input);
+    },
+    "session.deleted": async (input) => {
+      await sendEvent("session-end", input);
+    },
+    "session.idle": async (input) => {
+      await sendEvent("stop", input);
+    },
+    "tool.execute.before": async (input) => {
+      await sendEvent("pre-tool-use", input);
+    },
+    "tool.execute.after": async (input) => {
+      await sendEvent("post-tool-use", input);
+    },
+    "message.updated": async (input) => {
+      if (input.role === "user") {
+        await sendEvent("prompt-submit", input);
+      }
+    },
+  };
+}

--- a/scripts/reasonix-hooks.json
+++ b/scripts/reasonix-hooks.json
@@ -1,0 +1,100 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "session-start"]
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "pre-tool-use"]
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "post-tool-use"]
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "prompt-submit"]
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "stop"]
+          }
+        ]
+      }
+    ],
+    "TurnStart": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "pre-tool-use"]
+          }
+        ]
+      }
+    ],
+    "TurnEnd": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "stop"]
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "match": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-light-hook",
+            "args": ["--source", "reasonix", "session-end"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src-hook/src/main.rs
+++ b/src-hook/src/main.rs
@@ -16,10 +16,37 @@ struct HookEvent {
     session_id: String,
     cwd: Option<String>,
     tool_call: Option<String>,
+    tool_source: String,
 }
 
 fn main() {
-    let Some(raw_event_type) = env::args().nth(1) else {
+    let args: Vec<String> = env::args().collect();
+    let mut source = "claude-code".to_string();
+    let mut event_type_arg: Option<String> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--source" | "--tool-source" => {
+                i += 1;
+                if i < args.len() {
+                    source = args[i].clone();
+                }
+            }
+            "--help" => {
+                eprintln!("Usage: ai-light-hook [--source <tool>] <event_type>");
+                eprintln!("");
+                eprintln!("Tools: claude-code (default), opencode, reasonix");
+                return;
+            }
+            _ => {
+                event_type_arg = Some(args[i].clone());
+            }
+        }
+        i += 1;
+    }
+
+    let Some(raw_event_type) = event_type_arg else {
         append_log("ignored: missing event type argument");
         return;
     };
@@ -47,6 +74,7 @@ fn main() {
             .unwrap_or_else(|| "unknown".to_string()),
         cwd: extract_string(&payload, &["cwd"]),
         tool_call: extract_string(&payload, &["tool_name", "tool", "toolName"]),
+        tool_source: source,
     };
 
     match post_event(&target_url, &event) {
@@ -130,6 +158,20 @@ fn normalize_event_type(event_type: &str) -> String {
         "Notification" | "notification" => "notification",
         "Stop" | "stop" => "stop",
         "SessionEnd" | "session_end" | "sessionend" => "session-end",
+        // opencode event compatibility
+        "session_created" | "session.created" | "SessionCreated" => "session-start",
+        "session_deleted" | "session.deleted" | "SessionDeleted" => "session-end",
+        "session_idle" | "session.idle" | "SessionIdle" => "stop",
+        "tool_execute_before" | "tool.execute.before" | "tool.execute_before" => "pre-tool-use",
+        "tool_execute_after" | "tool.execute.after" | "tool.execute_after" => "post-tool-use",
+        "message_updated" | "message.updated" | "MessageUpdated" => "prompt-submit",
+        "tui_toast_show" | "tui.toast.show" | "TuiToastShow" => "notification",
+        "permission_asked" | "permission.asked" | "PermissionAsked" => "permission-request",
+        // reasonix event compatibility
+        "TurnStart" | "turn_start" | "turnstart" | "turn.start" => "pre-tool-use",
+        "TurnEnd" | "turn_end" | "turnend" | "turn.end" => "stop",
+        "PreModelCall" | "pre_model_call" | "premodelcall" => "pre-tool-use",
+        "PostModelCall" | "post_model_call" | "postmodelcall" => "post-tool-use",
         other => other,
     }
     .to_string()
@@ -195,6 +237,26 @@ mod tests {
         );
         assert_eq!(normalize_event_type("PostToolUse"), "post-tool-use");
         assert_eq!(normalize_event_type("SessionEnd"), "session-end");
+    }
+
+    #[test]
+    fn normalizes_opencode_event_names() {
+        assert_eq!(normalize_event_type("session.created"), "session-start");
+        assert_eq!(normalize_event_type("session.deleted"), "session-end");
+        assert_eq!(normalize_event_type("session.idle"), "stop");
+        assert_eq!(normalize_event_type("tool.execute.before"), "pre-tool-use");
+        assert_eq!(normalize_event_type("tool.execute.after"), "post-tool-use");
+        assert_eq!(normalize_event_type("message.updated"), "prompt-submit");
+        assert_eq!(normalize_event_type("tui.toast.show"), "notification");
+        assert_eq!(normalize_event_type("permission.asked"), "permission-request");
+    }
+
+    #[test]
+    fn normalizes_reasonix_event_names() {
+        assert_eq!(normalize_event_type("TurnStart"), "pre-tool-use");
+        assert_eq!(normalize_event_type("TurnEnd"), "stop");
+        assert_eq!(normalize_event_type("PreModelCall"), "pre-tool-use");
+        assert_eq!(normalize_event_type("PostModelCall"), "post-tool-use");
     }
 
     #[test]

--- a/src-tauri/src/hook_installer.rs
+++ b/src-tauri/src/hook_installer.rs
@@ -201,6 +201,231 @@ pub fn remove_ai_light_hooks(mut existing: Value) -> Result<Value, String> {
     Ok(existing)
 }
 
+// --- opencode integration ---
+
+pub fn get_opencode_config_path() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".config")
+        .join("opencode")
+        .join("opencode.json")
+}
+
+pub fn get_opencode_plugin_source_path() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".ai_light")
+        .join("opencode-plugin.js")
+}
+
+pub fn install_opencode_integration() -> Result<(), Box<dyn std::error::Error>> {
+    let plugin_source = bundled_opencode_plugin_path()?;
+    let plugin_dest = get_opencode_plugin_source_path();
+
+    if let Some(parent) = plugin_dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(&plugin_source, &plugin_dest)?;
+
+    let config_path = get_opencode_config_path();
+    let existing = if config_path.exists() {
+        let content = fs::read_to_string(&config_path)?;
+        serde_json::from_str(&content).unwrap_or_else(|_| json!({}))
+    } else {
+        json!({})
+    };
+
+    let plugin_path = plugin_dest.to_string_lossy().to_string();
+    let mut config = existing;
+    if !config.is_object() {
+        config = json!({});
+    }
+    if config.get("plugins").is_none() {
+        config["plugins"] = json!({});
+    }
+    config["plugins"][&plugin_path] = json!({});
+
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if config_path.exists() {
+        fs::copy(&config_path, config_path.with_extension("json.ai-light.bak"))?;
+    }
+    fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+
+    Ok(())
+}
+
+pub fn remove_opencode_integration() -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = get_opencode_config_path();
+    if config_path.exists() {
+        let content = fs::read_to_string(&config_path)?;
+        let mut config: Value = serde_json::from_str(&content).unwrap_or(json!({}));
+
+        if let Some(plugins) = config.get_mut("plugins").and_then(Value::as_object_mut) {
+            let plugin_path = get_opencode_plugin_source_path();
+            let plugin_key = plugin_path.to_string_lossy().to_string();
+            plugins.remove(&plugin_key);
+        }
+
+        fs::copy(&config_path, config_path.with_extension("json.ai-light.bak"))?;
+        fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+    }
+
+    let plugin_path = get_opencode_plugin_source_path();
+    if plugin_path.exists() {
+        fs::remove_file(plugin_path)?;
+    }
+
+    Ok(())
+}
+
+pub fn check_opencode_integration() -> Result<bool, Box<dyn std::error::Error>> {
+    let plugin_path = get_opencode_plugin_source_path();
+    if !plugin_path.exists() {
+        return Ok(false);
+    }
+
+    let config_path = get_opencode_config_path();
+    if !config_path.exists() {
+        return Ok(false);
+    }
+
+    let content = fs::read_to_string(&config_path)?;
+    let config: Value = serde_json::from_str(&content)?;
+    let plugin_key = plugin_path.to_string_lossy().to_string();
+
+    Ok(config
+        .get("plugins")
+        .and_then(Value::as_object)
+        .is_some_and(|plugins| plugins.contains_key(&plugin_key)))
+}
+
+// --- reasonix integration ---
+
+pub fn get_reasonix_settings_path() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".reasonix")
+        .join("settings.json")
+}
+
+pub fn install_reasonix_integration() -> Result<(), Box<dyn std::error::Error>> {
+    let hook_path = get_hook_binary_path();
+    if !hook_path.exists() {
+        return Err(format!("hook binary not found: {}", hook_path.display()).into());
+    }
+
+    let settings_path = get_reasonix_settings_path();
+    let existing = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)?;
+        serde_json::from_str(&content).unwrap_or_else(|_| json!({}))
+    } else {
+        json!({})
+    };
+
+    let hook_cmd = hook_path.to_string_lossy().to_string();
+    let mut config = existing;
+    if !config.is_object() {
+        config = json!({});
+    }
+
+    let reasonix_hooks = json!({
+        "SessionStart": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "session-start"].join(" ")
+            }
+        ],
+        "PreToolUse": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "pre-tool-use"].join(" ")
+            }
+        ],
+        "PostToolUse": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "post-tool-use"].join(" ")
+            }
+        ],
+        "UserPromptSubmit": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "prompt-submit"].join(" ")
+            }
+        ],
+        "Stop": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "stop"].join(" ")
+            }
+        ],
+        "TurnStart": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "pre-tool-use"].join(" ")
+            }
+        ],
+        "TurnEnd": [
+            {
+                "match": "",
+                "command": [hook_cmd.clone(), "--source", "reasonix", "stop"].join(" ")
+            }
+        ],
+        "SessionEnd": [
+            {
+                "match": "",
+                "command": [hook_cmd, "--source", "reasonix", "session-end"].join(" ")
+            }
+        ]
+    });
+
+    config["hooks"] = reasonix_hooks;
+
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if settings_path.exists() {
+        fs::copy(&settings_path, settings_path.with_extension("json.ai-light.bak"))?;
+    }
+    fs::write(&settings_path, serde_json::to_string_pretty(&config)?)?;
+
+    Ok(())
+}
+
+pub fn remove_reasonix_integration() -> Result<(), Box<dyn std::error::Error>> {
+    let settings_path = get_reasonix_settings_path();
+    if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)?;
+        let mut config: Value = serde_json::from_str(&content).unwrap_or(json!({}));
+
+        if config.is_object() {
+            config["hooks"] = json!({});
+        }
+
+        fs::copy(&settings_path, settings_path.with_extension("json.ai-light.bak"))?;
+        fs::write(&settings_path, serde_json::to_string_pretty(&config)?)?;
+    }
+
+    Ok(())
+}
+
+pub fn check_reasonix_integration() -> Result<bool, Box<dyn std::error::Error>> {
+    let settings_path = get_reasonix_settings_path();
+    if !settings_path.exists() {
+        return Ok(false);
+    }
+
+    let content = fs::read_to_string(&settings_path)?;
+    let config: Value = serde_json::from_str(&content)?;
+
+    Ok(config
+        .get("hooks")
+        .and_then(Value::as_object)
+        .is_some_and(|hooks| hooks.contains_key("SessionStart")))
+}
+
 fn hook_binary_name() -> &'static str {
     if cfg!(windows) {
         "ai-light-hook.exe"
@@ -216,6 +441,97 @@ fn bundled_hook_candidates(resource_dir: &Path) -> Vec<PathBuf> {
         resource_dir.join("ai-light-hook"),
     ]
 }
+
+fn bundled_opencode_plugin_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let dest = get_opencode_plugin_source_path();
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&dest, OPENCODE_PLUGIN_SOURCE)?;
+    Ok(dest)
+}
+
+const OPENCODE_PLUGIN_SOURCE: &str = r#"/**
+ * AI Light OpenCode Plugin
+ *
+ * Sends OpenCode session events to AI Light's local HTTP server.
+ *
+ * ## Installation
+ *
+ * Add to ~/.config/opencode/opencode.json:
+ * {
+ *   "plugins": {
+ *     "https://raw.githubusercontent.com/lcy05/ai-light/main/scripts/opencode-plugin.js": {}
+ *   }
+ * }
+ *
+ * Or copy this file to ~/.config/opencode/plugins/ai-light.js
+ */
+
+/// <reference types="@opencode-ai/plugin" />
+
+/**
+ * @type {import("@opencode-ai/plugin").Plugin}
+ */
+export default async function aiLightPlugin(ctx) {
+  const AI_LIGHT_URL =
+    process.env.AI_LIGHT_URL ||
+    "http://127.0.0.1:17321";
+
+  function baseUrl() {
+    return AI_LIGHT_URL.replace(/\/+$/, "");
+  }
+
+  async function sendEvent(eventType, payload) {
+    try {
+      const url = `${baseUrl()}/events`;
+      const body = JSON.stringify({
+        event_type: eventType,
+        session_id: payload.session?.id || "unknown",
+        sessionId: payload.session?.id || "unknown",
+        cwd: payload.session?.cwd || payload.cwd || process.cwd(),
+        tool_call: payload.tool?.name || payload.toolName || null,
+        toolName: payload.tool?.name || payload.toolName || null,
+        tool_source: "opencode",
+        source: "opencode",
+      });
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      if (!response.ok) {
+        console.error(`AI Light: event ${eventType} failed (${response.status})`);
+      }
+    } catch (error) {
+      // AI Light not running -- silently ignore
+    }
+  }
+
+  return {
+    "session.created": async (input) => {
+      await sendEvent("session-start", input);
+    },
+    "session.deleted": async (input) => {
+      await sendEvent("session-end", input);
+    },
+    "session.idle": async (input) => {
+      await sendEvent("stop", input);
+    },
+    "tool.execute.before": async (input) => {
+      await sendEvent("pre-tool-use", input);
+    },
+    "tool.execute.after": async (input) => {
+      await sendEvent("post-tool-use", input);
+    },
+    "message.updated": async (input) => {
+      if (input.role === "user") {
+        await sendEvent("prompt-submit", input);
+      }
+    },
+  };
+}
+"#;
 
 fn remove_existing_ai_light_hooks(event_hooks: &mut Vec<Value>) {
     event_hooks.retain(|entry| !entry_contains_ai_light_hook(entry));

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -18,9 +18,28 @@ pub struct HookEvent {
     pub cwd: Option<String>,
     #[serde(default, alias = "tool", alias = "toolName", alias = "tool_name")]
     pub tool_call: Option<String>,
+    #[serde(default = "default_source", alias = "source", alias = "toolSource", alias = "tool_source")]
+    pub tool_source: String,
+}
+
+fn default_session_id() -> String {
+    "unknown".to_string()
+}
+
+fn default_source() -> String {
+    "claude-code".to_string()
 }
 
 impl HookEvent {
+    pub fn tool_source_to_tool(source: &str) -> Tool {
+        match source.to_lowercase().replace(['-', '_', ' '], "") {
+            s if s == "claudecode" || s == "claude" || s == "claude-code" => Tool::ClaudeCode,
+            s if s == "opencode" || s == "open-code" => Tool::OpenCode,
+            s if s == "reasonix" => Tool::Reasonix,
+            _ => Tool::ClaudeCode,
+        }
+    }
+
     pub fn event_type_to_status(event_type: &str) -> Option<Status> {
         match event_type {
             "session-start" => Some(Status::Idle),
@@ -94,10 +113,6 @@ pub fn start_http_server(
     Ok(port)
 }
 
-fn default_session_id() -> String {
-    "unknown".to_string()
-}
-
 fn handle_connection(mut stream: TcpStream, aggregator: Arc<StateAggregator>) -> io::Result<()> {
     let request = read_http_request(&mut stream)?;
     let Some((request_line, body)) = request else {
@@ -167,6 +182,8 @@ fn read_http_request(stream: &mut TcpStream) -> io::Result<Option<(String, Strin
 }
 
 fn apply_hook_event(aggregator: &StateAggregator, event: HookEvent) {
+    let tool = HookEvent::tool_source_to_tool(&event.tool_source);
+
     match event.event_type.as_str() {
         "session-start" => {
             let cwd = event
@@ -176,7 +193,7 @@ fn apply_hook_event(aggregator: &StateAggregator, event: HookEvent) {
                 .or_else(|| std::env::current_dir().ok())
                 .unwrap_or_else(|| PathBuf::from("."));
 
-            aggregator.add_session(event.session_id, Tool::ClaudeCode, &cwd, Status::Idle);
+            aggregator.add_session(event.session_id, tool, &cwd, Status::Idle);
         }
         "session-end" => {
             aggregator.remove_session(&event.session_id);
@@ -263,5 +280,14 @@ mod tests {
         let headers = "POST /events HTTP/1.1\r\ncontent-length: 42\r\n";
 
         assert_eq!(parse_content_length(headers), 42);
+    }
+
+    #[test]
+    fn maps_tool_source_to_tool() {
+        assert_eq!(HookEvent::tool_source_to_tool("claude-code"), Tool::ClaudeCode);
+        assert_eq!(HookEvent::tool_source_to_tool("opencode"), Tool::OpenCode);
+        assert_eq!(HookEvent::tool_source_to_tool("open-code"), Tool::OpenCode);
+        assert_eq!(HookEvent::tool_source_to_tool("reasonix"), Tool::Reasonix);
+        assert_eq!(HookEvent::tool_source_to_tool("unknown"), Tool::ClaudeCode);
     }
 }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -4,7 +4,9 @@ use ai_light::config::{
     load_app_config, load_runtime_config, save_app_config,
 };
 use ai_light::hook_installer::{
-    check_hooks_installed, install_hooks, preview_hook_config, remove_hooks,
+    check_hooks_installed, check_opencode_integration, check_reasonix_integration,
+    install_hooks, install_opencode_integration, install_reasonix_integration, preview_hook_config,
+    remove_hooks, remove_opencode_integration, remove_reasonix_integration,
 };
 use ai_light::types::LightState;
 use serde::{Deserialize, Serialize};
@@ -28,6 +30,8 @@ pub struct Diagnostics {
     pub runtime_exists: bool,
     pub light_count: usize,
     pub recent_log: String,
+    pub opencode_integration: bool,
+    pub reasonix_integration: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -127,6 +131,8 @@ pub fn get_diagnostics(aggregator: State<Arc<StateAggregator>>) -> Diagnostics {
         runtime_exists: get_runtime_path().exists(),
         light_count: aggregator.get_lights().len(),
         recent_log: recent_log(&log_path),
+        opencode_integration: check_opencode_integration().unwrap_or(false),
+        reasonix_integration: check_reasonix_integration().unwrap_or(false),
     }
 }
 
@@ -246,6 +252,40 @@ pub fn preview_hook_config_command() -> Result<String, String> {
 #[tauri::command]
 pub fn quit_app(app: AppHandle) {
     app.exit(0);
+}
+
+// --- opencode integration commands ---
+
+#[tauri::command]
+pub fn check_opencode() -> bool {
+    check_opencode_integration().unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn install_opencode_command() -> Result<(), String> {
+    install_opencode_integration().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn remove_opencode_command() -> Result<(), String> {
+    remove_opencode_integration().map_err(|error| error.to_string())
+}
+
+// --- reasonix integration commands ---
+
+#[tauri::command]
+pub fn check_reasonix() -> bool {
+    check_reasonix_integration().unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn install_reasonix_command() -> Result<(), String> {
+    install_reasonix_integration().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn remove_reasonix_command() -> Result<(), String> {
+    remove_reasonix_integration().map_err(|error| error.to_string())
 }
 
 fn open_path(path: &str) -> Result<(), String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,7 +45,13 @@ fn main() {
             ipc::install_hooks_command,
             ipc::remove_hooks_command,
             ipc::preview_hook_config_command,
-            ipc::quit_app
+            ipc::quit_app,
+            ipc::check_opencode,
+            ipc::install_opencode_command,
+            ipc::remove_opencode_command,
+            ipc::check_reasonix,
+            ipc::install_reasonix_command,
+            ipc::remove_reasonix_command,
         ])
         .setup(move |app| {
             if existing_instance_is_healthy() {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -13,6 +15,43 @@ pub enum Status {
 pub enum Tool {
     ClaudeCode,
     Codex,
+    OpenCode,
+    Reasonix,
+}
+
+impl Tool {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Tool::ClaudeCode => "Claude Code",
+            Tool::Codex => "Codex",
+            Tool::OpenCode => "OpenCode",
+            Tool::Reasonix => "Reasonix",
+        }
+    }
+
+    pub fn all() -> &'static [Tool] {
+        &[Tool::ClaudeCode, Tool::Codex, Tool::OpenCode, Tool::Reasonix]
+    }
+}
+
+impl FromStr for Tool {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().replace(['-', '_', ' '], "") {
+            s if s == "claudecode" || s == "claude" || s == "claude-code" => Ok(Tool::ClaudeCode),
+            s if s == "codex" => Ok(Tool::Codex),
+            s if s == "opencode" || s == "open-code" => Ok(Tool::OpenCode),
+            s if s == "reasonix" => Ok(Tool::Reasonix),
+            _ => Err(format!("unknown tool: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for Tool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.label())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -47,7 +86,6 @@ impl LightState {
         }
     }
 
-    /// Aggregate status from all sessions (max by severity)
     pub fn aggregate_status(&mut self) {
         self.status = self
             .sessions

--- a/src/app.js
+++ b/src/app.js
@@ -207,8 +207,14 @@ function tooltipFor(lightState) {
     lightState.status || "Idle",
   ];
 
+  if (lightState.sessions && lightState.sessions.length > 0) {
+    const tools = [...new Set(lightState.sessions.map((s) => s.tool || "?"))];
+    parts.push("───");
+    parts.push("Tools: " + tools.join(", "));
+  }
+
   if (lightState.last_tool_call) {
-    parts.push(lightState.last_tool_call);
+    parts.push("Last: " + lightState.last_tool_call);
   }
 
   return parts.join("\n");

--- a/src/settings.css
+++ b/src/settings.css
@@ -1,176 +1,201 @@
+:root {
+  --bg: #1a1a2e;
+  --surface: #16213e;
+  --text: #e0e0e0;
+  --text-secondary: #a0a0b0;
+  --primary: #0f3460;
+  --accent: #e94560;
+  --danger: #c0392b;
+  --success: #27ae60;
+  --border: #2a2a4a;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+
 * {
+  margin: 0;
+  padding: 0;
   box-sizing: border-box;
 }
 
-:root {
-  color-scheme: dark;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #171b22;
-  color: #e5e7eb;
-}
-
 body {
-  min-height: 100vh;
-  margin: 0;
-  display: grid;
-  place-items: center;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 34%),
-    #171b22;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 20px;
 }
 
 .settings {
-  width: min(420px, calc(100vw - 40px));
+  max-width: 480px;
+  margin: 0 auto;
 }
 
 header {
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 h1 {
-  margin: 0 0 8px;
-  font-size: 20px;
-  font-weight: 650;
-  letter-spacing: 0;
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
-p {
-  min-height: 17px;
-  margin: 0;
-  overflow: hidden;
-  color: #94a3b8;
-  font-size: 12px;
-  line-height: 1.4;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+#config-path {
+  font-size: 11px;
+  color: var(--text-secondary);
+  word-break: break-all;
 }
 
 .field {
-  display: grid;
-  grid-template-columns: 96px 1fr;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 }
 
-label,
-dt {
-  color: #cbd5e1;
-  font-size: 13px;
+.field label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
 }
 
 select,
-input {
+input[type="number"] {
   width: 100%;
-  height: 34px;
-  padding: 0 10px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 7px;
-  color: #f8fafc;
-  background: #11151c;
-  font: inherit;
-  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 14px;
+  outline: none;
 }
 
 select:focus,
 input:focus {
-  border-color: #38bdf8;
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.14);
+  border-color: var(--accent);
 }
 
 dl {
-  margin: 16px 0 0;
+  margin-bottom: 16px;
 }
 
 dl div {
-  display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 12px;
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+dt {
+  color: var(--text-secondary);
+  font-size: 12px;
 }
 
 dd {
-  margin: 0;
-  color: #e5e7eb;
   font-size: 13px;
+  font-family: monospace;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 20px 0;
 }
 
 .integration {
-  display: grid;
-  gap: 8px;
-  margin-top: 18px;
-  padding-top: 14px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: 20px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
 }
 
-#status {
-  min-height: 20px;
-  margin-top: 14px;
-  color: #93c5fd;
-  font-size: 13px;
+.integration h2 {
+  margin-bottom: 2px;
 }
 
-#status.error {
-  color: #fca5a5;
+.hint {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
 }
 
-footer {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  margin-top: 18px;
+.integration button {
+  margin-right: 8px;
+  margin-bottom: 4px;
+}
+
+.integration-status {
+  display: inline-block;
+  font-size: 11px;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.integration-status.installed {
+  color: var(--success);
 }
 
 button {
-  height: 32px;
-  min-width: 76px;
-  padding: 0 13px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 7px;
-  color: #e5e7eb;
-  background: #252b35;
-  font: inherit;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--primary);
+  color: var(--text);
   font-size: 13px;
   cursor: pointer;
+  transition: background 0.15s;
 }
 
-button:hover {
-  background: #303847;
+button:hover:not(:disabled) {
+  background: #1a4a7a;
 }
 
 button:disabled {
-  cursor: default;
-  opacity: 0.62;
-}
-
-button.primary {
-  border-color: #2563eb;
-  background: #2563eb;
-  color: white;
-}
-
-button.primary:hover {
-  background: #1d4ed8;
-}
-
-button#install-integration {
-  width: 100%;
-  border-color: rgba(56, 189, 248, 0.38);
-  color: #dbeafe;
-  background: rgba(14, 116, 144, 0.32);
-}
-
-button#install-integration:hover {
-  background: rgba(8, 145, 178, 0.44);
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 button.danger {
-  width: 100%;
-  border-color: rgba(248, 113, 113, 0.38);
-  color: #fecaca;
-  background: rgba(127, 29, 29, 0.34);
+  background: var(--danger);
+  border-color: var(--danger);
 }
 
-button.danger:hover {
-  background: rgba(153, 27, 27, 0.48);
+button.danger:hover:not(:disabled) {
+  background: #e74c3c;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 500;
+}
+
+button.primary:hover:not(:disabled) {
+  background: #ff6b7a;
+}
+
+footer {
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+#status {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  min-height: 18px;
+}
+
+#status.error {
+  color: var(--accent);
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -33,13 +33,30 @@
         </div>
       </dl>
 
+      <hr />
+
       <section class="integration">
-        <button id="install-integration" type="button">
-          Install Claude Integration
-        </button>
-        <button id="remove-integration" class="danger" type="button">
-          Remove Claude Integration
-        </button>
+        <h2>Claude Code</h2>
+        <p class="hint">Installs hooks to ~/.claude/settings.json</p>
+        <button id="install-claude" type="button">Install Claude Integration</button>
+        <button id="remove-claude" class="danger" type="button">Remove Claude Integration</button>
+        <span id="claude-status" class="integration-status"></span>
+      </section>
+
+      <section class="integration">
+        <h2>OpenCode</h2>
+        <p class="hint">Registers plugin in ~/.config/opencode/opencode.json</p>
+        <button id="install-opencode" type="button">Install OpenCode Integration</button>
+        <button id="remove-opencode" class="danger" type="button">Remove OpenCode Integration</button>
+        <span id="opencode-status" class="integration-status"></span>
+      </section>
+
+      <section class="integration">
+        <h2>Reasonix</h2>
+        <p class="hint">Writes hooks to ~/.reasonix/settings.json</p>
+        <button id="install-reasonix" type="button">Install Reasonix Integration</button>
+        <button id="remove-reasonix" class="danger" type="button">Remove Reasonix Integration</button>
+        <span id="reasonix-status" class="integration-status"></span>
       </section>
 
       <div id="status" role="status"></div>

--- a/src/settings.js
+++ b/src/settings.js
@@ -10,13 +10,20 @@ const runtimePort = document.getElementById("runtime-port");
 const statusEl = document.getElementById("status");
 const saveButton = document.getElementById("save");
 const closeButton = document.getElementById("close");
-const installIntegrationButton = document.getElementById("install-integration");
-const removeIntegrationButton = document.getElementById("remove-integration");
+
+const claudeStatus = document.getElementById("claude-status");
+const opencodeStatus = document.getElementById("opencode-status");
+const reasonixStatus = document.getElementById("reasonix-status");
 
 saveButton.addEventListener("click", saveSettings);
 closeButton.addEventListener("click", () => currentWindow?.close());
-installIntegrationButton.addEventListener("click", installIntegration);
-removeIntegrationButton.addEventListener("click", removeIntegration);
+
+document.getElementById("install-claude").addEventListener("click", () => installIntegration("claude"));
+document.getElementById("remove-claude").addEventListener("click", () => removeIntegration("claude"));
+document.getElementById("install-opencode").addEventListener("click", () => installIntegration("opencode"));
+document.getElementById("remove-opencode").addEventListener("click", () => removeIntegration("opencode"));
+document.getElementById("install-reasonix").addEventListener("click", () => installIntegration("reasonix"));
+document.getElementById("remove-reasonix").addEventListener("click", () => removeIntegration("reasonix"));
 
 loadSettings();
 
@@ -35,6 +42,21 @@ async function loadSettings() {
     setStatus(String(error), true);
   } finally {
     setBusy(false);
+  }
+
+  refreshIntegrationStatus("claude", "check_hooks");
+  refreshIntegrationStatus("opencode", "check_opencode");
+  refreshIntegrationStatus("reasonix", "check_reasonix");
+}
+
+async function refreshIntegrationStatus(name, checkCommand) {
+  const el = document.getElementById(`${name}-status`);
+  try {
+    const installed = await invoke(checkCommand);
+    el.textContent = installed ? "✓ Installed" : "— Not installed";
+    el.className = "integration-status " + (installed ? "installed" : "");
+  } catch {
+    el.textContent = "? Unknown";
   }
 }
 
@@ -59,34 +81,55 @@ async function saveSettings() {
   }
 }
 
-async function installIntegration() {
+async function installIntegration(tool) {
   setBusy(true);
 
+  const commands = {
+    claude: { install: "install_hooks_command", remove: "remove_hooks_command", label: "Claude" },
+    opencode: { install: "install_opencode_command", remove: "remove_opencode_command", label: "OpenCode" },
+    reasonix: { install: "install_reasonix_command", remove: "remove_reasonix_command", label: "Reasonix" },
+  };
+
+  const cmd = commands[tool];
+  const checkCommand = { claude: "check_hooks", opencode: "check_opencode", reasonix: "check_reasonix" }[tool];
+
   try {
-    await invoke("install_hooks_command");
-    setStatus("Claude integration installed. Restart Claude Code to apply.");
+    await invoke(cmd.install);
+    setStatus(`${cmd.label} integration installed.`);
   } catch (error) {
     setStatus(String(error), true);
   } finally {
     setBusy(false);
+    refreshIntegrationStatus(tool, checkCommand);
   }
 }
 
-async function removeIntegration() {
+async function removeIntegration(tool) {
+  const labels = { claude: "Claude Code", opencode: "OpenCode", reasonix: "Reasonix" };
   const confirmed = confirm(
-    "Remove AI Light hooks from Claude Code settings and delete the hook helper?",
+    `Remove AI Light ${labels[tool]} integration?`,
   );
   if (!confirmed) return;
 
   setBusy(true);
 
+  const commands = {
+    claude: { remove: "remove_hooks_command" },
+    opencode: { remove: "remove_opencode_command" },
+    reasonix: { remove: "remove_reasonix_command" },
+  };
+
+  const cmd = commands[tool];
+  const checkCommand = { claude: "check_hooks", opencode: "check_opencode", reasonix: "check_reasonix" }[tool];
+
   try {
-    await invoke("remove_hooks_command");
-    setStatus("Claude integration removed. Restart Claude Code to apply.");
+    await invoke(cmd.remove);
+    setStatus(`${labels[tool]} integration removed.`);
   } catch (error) {
     setStatus(String(error), true);
   } finally {
     setBusy(false);
+    refreshIntegrationStatus(tool, checkCommand);
   }
 }
 
@@ -116,10 +159,10 @@ function ensureBindOption(value) {
 }
 
 function setBusy(isBusy) {
-  saveButton.disabled = isBusy;
-  closeButton.disabled = isBusy;
-  installIntegrationButton.disabled = isBusy;
-  removeIntegrationButton.disabled = isBusy;
+  const buttons = document.querySelectorAll("button");
+  for (const btn of buttons) {
+    btn.disabled = isBusy;
+  }
   bindSelect.disabled = isBusy;
   portInput.disabled = isBusy;
 }


### PR DESCRIPTION
## Summary

Add support for OpenCode and Reasonix AI coding assistants alongside existing Claude Code and Codex support.

## Changes

### Backend (Rust)
- types.rs: Add "OpenCode" and "Reasonix" variants to Tool enum
- http_server.rs: Add tool_source field to HookEvent for multi-tool detection
- hook_installer.rs: Add install/remove/check for opencode and reasonix integration
- ipc.rs: Add 6 new IPC commands, extend Diagnostics with integration status
- main.rs: Register all new IPC commands

### Hook binary
- src-hook/main.rs: Add --source CLI argument, normalize opencode and reasonix event names

### Frontend
- settings.html/js/css: Three integration sections with install/remove buttons and status
- app.js: Tooltip now shows active tools per project

### Integration files
- scripts/opencode-plugin.js: OpenCode plugin that sends events to AI Light
- scripts/reasonix-hooks.json: Reasonix hook configuration template

## How it works

All three tools share the same POST /events endpoint, differentiated by tool_source:
- Claude Code: ai-light-hook without --source (default)
- OpenCode: JS plugin sets tool_source: "opencode"
- Reasonix: ai-light-hook --source reasonix

## Installation

From Settings UI:
- Claude Code: Click "Install Claude Integration"
- OpenCode: Click "Install OpenCode Integration"
- Reasonix: Click "Install Reasonix Integration"

Manual:
- OpenCode: Copy scripts/opencode-plugin.js to ~/.config/opencode/plugins/
- Reasonix: Copy scripts/reasonix-hooks.json to ~/.reasonix/settings.json
